### PR TITLE
fix: subscriptionsへの移行を初回作成時のみにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.ini
 bot.db
+__pycache__/

--- a/database.py
+++ b/database.py
@@ -1,0 +1,63 @@
+import sqlite3
+
+
+DB_PATH = "bot.db"
+
+
+def _table_exists(cursor, table_name):
+    return (
+        cursor.execute(
+            """
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'table' AND name = ?
+            """,
+            (table_name,),
+        ).fetchone()
+        is not None
+    )
+
+
+def init_db(db_path=DB_PATH):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        cursor = conn.cursor()
+
+        if _table_exists(cursor, "subscriptions"):
+            return False
+
+        cursor.execute(
+            """
+            CREATE TABLE subscriptions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                discord_id INTEGER,
+                atcoder_handle TEXT NOT NULL,
+                channel_id INTEGER NOT NULL,
+                last_submission_id INTEGER,
+                last_checked_time INTEGER,
+                UNIQUE(atcoder_handle, channel_id)
+            )
+            """
+        )
+
+        if _table_exists(cursor, "users"):
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO subscriptions (
+                    discord_id,
+                    atcoder_handle,
+                    channel_id,
+                    last_submission_id,
+                    last_checked_time
+                )
+                SELECT
+                    discord_id,
+                    atcoder_handle,
+                    channel_id,
+                    last_submission_id,
+                    last_checked_time
+                FROM users
+                """
+            )
+
+        return True

--- a/main.py
+++ b/main.py
@@ -12,62 +12,13 @@ from discord import app_commands
 from discord.ext import commands, tasks
 import pytz
 
+from database import DB_PATH, init_db
 
-DB_PATH = "bot.db"
+
 ATCODER_PROFILE_URL = "https://atcoder.jp/users/{handle}"
 ATCODER_AVATAR_URL = "https://img.atcoder.jp/assets/icon/avatar.png"
 ATCODER_PROBLEMS_URL = "https://kenkoooo.com/atcoder/resources/problems.json"
 ATCODER_DIFFICULTY_URL = "https://kenkoooo.com/atcoder/resources/problem-models.json"
-
-
-def init_db():
-    conn = sqlite3.connect(DB_PATH)
-    c = conn.cursor()
-    c.execute(
-        """
-        CREATE TABLE IF NOT EXISTS users (
-            discord_id INTEGER PRIMARY KEY,
-            atcoder_handle TEXT NOT NULL,
-            channel_id INTEGER NOT NULL,
-            last_submission_id INTEGER,
-            last_checked_time INTEGER
-        )
-        """
-    )
-    c.execute(
-        """
-        CREATE TABLE IF NOT EXISTS subscriptions (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            discord_id INTEGER,
-            atcoder_handle TEXT NOT NULL,
-            channel_id INTEGER NOT NULL,
-            last_submission_id INTEGER,
-            last_checked_time INTEGER,
-            UNIQUE(atcoder_handle, channel_id)
-        )
-        """
-    )
-    c.execute(
-        """
-        INSERT OR IGNORE INTO subscriptions (
-            discord_id,
-            atcoder_handle,
-            channel_id,
-            last_submission_id,
-            last_checked_time
-        )
-        SELECT
-            discord_id,
-            atcoder_handle,
-            channel_id,
-            last_submission_id,
-            last_checked_time
-        FROM users
-        """
-    )
-    conn.commit()
-    conn.close()
-
 
 init_db()
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,120 @@
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from database import init_db
+
+
+USERS_SCHEMA = """
+CREATE TABLE users (
+    discord_id INTEGER PRIMARY KEY,
+    atcoder_handle TEXT NOT NULL,
+    channel_id INTEGER NOT NULL,
+    last_submission_id INTEGER,
+    last_checked_time INTEGER
+)
+"""
+
+
+class InitDbTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.temp_dir.name) / "bot.db"
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def connect(self):
+        return sqlite3.connect(self.db_path)
+
+    def test_migrates_users_when_subscriptions_is_created(self):
+        with self.connect() as conn:
+            conn.execute(USERS_SCHEMA)
+            conn.executemany(
+                """
+                INSERT INTO users VALUES (?, ?, ?, ?, ?)
+                """,
+                [
+                    (1, "alice", 101, 1001, 10001),
+                    (2, "bob", 102, None, 10002),
+                ],
+            )
+
+        self.assertTrue(init_db(self.db_path))
+
+        with self.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT discord_id, atcoder_handle, channel_id,
+                       last_submission_id, last_checked_time
+                FROM subscriptions
+                ORDER BY discord_id
+                """
+            ).fetchall()
+
+        self.assertEqual(
+            rows,
+            [
+                (1, "alice", 101, 1001, 10001),
+                (2, "bob", 102, None, 10002),
+            ],
+        )
+
+    def test_does_not_copy_users_again_when_subscriptions_exists(self):
+        with self.connect() as conn:
+            conn.execute(USERS_SCHEMA)
+            conn.execute(
+                "INSERT INTO users VALUES (?, ?, ?, ?, ?)",
+                (1, "alice", 101, 1001, 10001),
+            )
+
+        init_db(self.db_path)
+
+        with self.connect() as conn:
+            conn.execute(
+                """
+                UPDATE subscriptions
+                SET last_submission_id = ?, last_checked_time = ?
+                WHERE atcoder_handle = ? AND channel_id = ?
+                """,
+                (2001, 20001, "alice", 101),
+            )
+            conn.execute(
+                "INSERT INTO users VALUES (?, ?, ?, ?, ?)",
+                (2, "bob", 102, 1002, 10002),
+            )
+
+        self.assertFalse(init_db(self.db_path))
+
+        with self.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT atcoder_handle, last_submission_id, last_checked_time
+                FROM subscriptions
+                """
+            ).fetchall()
+
+        self.assertEqual(rows, [("alice", 2001, 20001)])
+
+    def test_fresh_database_does_not_create_legacy_users_table(self):
+        self.assertTrue(init_db(self.db_path))
+
+        with self.connect() as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    """
+                    SELECT name
+                    FROM sqlite_master
+                    WHERE type = 'table'
+                    """
+                )
+            }
+
+        self.assertIn("subscriptions", tables)
+        self.assertNotIn("users", tables)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

起動のたびに旧 users テーブルから subscriptions テーブルへコピーしていた処理を、subscriptions テーブルが存在しない場合だけ実行する一度限りの移行に変更します。

## 変更内容

- DB初期化処理を database.py に分離
- subscriptions が既に存在する場合は移行せず終了
- subscriptions の初回作成時に限り、users が存在すればデータをコピー
- 新規環境では旧 users テーブルを作成しない
- 初期化処理をトランザクションで保護
- 初回移行、再コピー防止、新規DBを検証するテストを追加

## 本番DBの調査結果

本番DBは読み取り専用で確認しました。

- users: 93件
- subscriptions: 107件
- 旧データの移行漏れ、Discord ID不一致、進捗値の逆行: 0件
- 重複、必須値NULL、型異常: 0件
- SQLite quick_check: ok
- 移行後の新規登録: 14件
- 移行後に進捗更新された旧データ: 40件

移行データには問題ありませんでした。

なお、移行とは別に、Discordの 403 Missing Access がサービスログへ多数記録されています。通知権限を失ったチャンネルに対する既存の運用上の問題であり、このPRの変更対象には含めていません。

## テスト

- python3 -m unittest discover -v: 3件成功
- python3 -m compileall -q main.py database.py tests: 成功
- 本番DBの読み取りスナップショットで既存テーブル時の件数、DBファイル内容が変更されないことを確認
- スナップショットの SQLite quick_check: ok