### PR TITLE
feat: ユーザー登録解除メニューを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 1. サーバーに[BOT](https://discord.com/oauth2/authorize?client_id=1342526334529835048&permissions=280576&integration_type=0&scope=bot)を招待
 2. `/register`コマンドを使用して「AtCoderハンドル・通知を送信するチャンネル」を指定し、必要ならDiscordユーザーもあわせて登録する
+3. 登録を解除する場合は`/unregister`コマンドから対象を選択する
 
 # Manual Setup (Self hosted)
 1. ルートディレクトリに`config.ini`を作成

--- a/database.py
+++ b/database.py
@@ -81,6 +81,49 @@ def delete_subscriptions_for_channel(channel_id, db_path=DB_PATH):
         conn.close()
 
 
+def get_subscriptions_for_channels(channel_ids, db_path=DB_PATH):
+    channel_ids = tuple(channel_ids)
+    if not channel_ids:
+        return []
+
+    placeholders = ", ".join("?" for _ in channel_ids)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        return conn.execute(
+            f"""
+            SELECT id, discord_id, atcoder_handle, channel_id
+            FROM subscriptions
+            WHERE channel_id IN ({placeholders})
+            ORDER BY atcoder_handle COLLATE NOCASE, channel_id, id
+            """,
+            channel_ids,
+        ).fetchall()
+
+
+def delete_subscriptions(subscriptions, discord_id=None, db_path=DB_PATH):
+    subscriptions = tuple(subscriptions)
+    if not subscriptions:
+        return 0
+
+    if discord_id is None:
+        query = "DELETE FROM subscriptions WHERE id = ? AND channel_id = ?"
+        parameters = subscriptions
+    else:
+        query = (
+            "DELETE FROM subscriptions "
+            "WHERE id = ? AND channel_id = ? AND discord_id = ?"
+        )
+        parameters = [
+            (subscription_id, channel_id, discord_id)
+            for subscription_id, channel_id in subscriptions
+        ]
+
+    with sqlite3.connect(db_path) as conn:
+        before = conn.total_changes
+        conn.executemany(query, parameters)
+        return conn.total_changes - before
+
+
 def get_submission_poll_time(db_path=DB_PATH):
     with sqlite3.connect(db_path) as conn:
         return conn.execute(

--- a/database.py
+++ b/database.py
@@ -100,12 +100,23 @@ def get_subscriptions_for_channels(channel_ids, db_path=DB_PATH):
         ).fetchall()
 
 
-def delete_subscriptions(subscriptions, discord_id=None, db_path=DB_PATH):
+def delete_subscriptions(
+    subscriptions,
+    discord_id=None,
+    db_path=DB_PATH,
+    unlinked_only=False,
+):
     subscriptions = tuple(subscriptions)
     if not subscriptions:
         return 0
 
-    if discord_id is None:
+    if unlinked_only:
+        query = (
+            "DELETE FROM subscriptions "
+            "WHERE id = ? AND channel_id = ? AND discord_id IS NULL"
+        )
+        parameters = subscriptions
+    elif discord_id is None:
         query = "DELETE FROM subscriptions WHERE id = ? AND channel_id = ?"
         parameters = subscriptions
     else:

--- a/main.py
+++ b/main.py
@@ -359,6 +359,10 @@ class UnregisterView(discord.ui.View):
                 record
                 for record in records
                 if record["discord_id"] == self.user_id
+                or (
+                    record["discord_id"] is None
+                    and self.can_view_channel(record["channel_id"])
+                )
             ]
         self.records = records
         self.page = min(self.page, max(0, self.page_count - 1))
@@ -375,12 +379,16 @@ class UnregisterView(discord.ui.View):
         start = self.page * UNREGISTER_PAGE_SIZE
         return self.records[start : start + UNREGISTER_PAGE_SIZE]
 
+    def can_view_channel(self, channel_id, member=None):
+        channel = self.guild.get_channel(channel_id)
+        return bool(
+            channel
+            and channel.permissions_for(member or self.member).view_channel
+        )
+
     def channel_text(self, channel_id, plain=False):
         channel = self.guild.get_channel(channel_id)
-        if (
-            channel is not None
-            and channel.permissions_for(self.member).view_channel
-        ):
+        if self.can_view_channel(channel_id):
             return f"#{channel.name}" if plain else channel.mention
         return "閲覧権限のないチャンネル"
 
@@ -394,7 +402,7 @@ class UnregisterView(discord.ui.View):
 
     def build_embed(self):
         if self.confirmation is not None:
-            label, subscriptions = self.confirmation
+            label, subscriptions, _ = self.confirmation
             return discord.Embed(
                 title="登録解除の確認",
                 description=(
@@ -423,6 +431,8 @@ class UnregisterView(discord.ui.View):
             value = f"通知先: {self.channel_text(record['channel_id'])}"
             if self.mode == "admin":
                 value += f"\nユーザー: {self.owner_text(record['discord_id'])}"
+            elif record["discord_id"] is None:
+                value += "\n共有登録（Discordユーザー未紐づけ）"
             embed.add_field(
                 name=record["atcoder_handle"],
                 value=value,
@@ -464,6 +474,8 @@ class UnregisterView(discord.ui.View):
                 if self.mode == "admin":
                     owner = self.owner_text(record["discord_id"], plain=True)
                     description += f" / {owner}"
+                elif record["discord_id"] is None:
+                    description += " / 共有登録"
                 options.append(
                     discord.SelectOption(
                         label=record["atcoder_handle"][:100],
@@ -506,17 +518,21 @@ class UnregisterView(discord.ui.View):
             remove.callback = self.confirm_selected
             self.add_item(remove)
 
-            remove_all = discord.ui.Button(
-                label=(
-                    "このサーバーの全登録を解除"
-                    if self.mode == "admin"
-                    else "自分の登録をすべて解除"
-                ),
-                style=discord.ButtonStyle.danger,
-                row=2,
-            )
-            remove_all.callback = self.confirm_all
-            self.add_item(remove_all)
+            if self.mode == "admin" or any(
+                record["discord_id"] == self.user_id
+                for record in self.records
+            ):
+                remove_all = discord.ui.Button(
+                    label=(
+                        "このサーバーの全登録を解除"
+                        if self.mode == "admin"
+                        else "自分の登録をすべて解除"
+                    ),
+                    style=discord.ButtonStyle.danger,
+                    row=2,
+                )
+                remove_all.callback = self.confirm_all
+                self.add_item(remove_all)
 
         if self.mode == "admin":
             back = discord.ui.Button(
@@ -617,8 +633,13 @@ class UnregisterView(discord.ui.View):
         if self.mode == "admin" and not await self.ensure_manager(interaction):
             return
         self.confirmation = (
-            f"「{selected['atcoder_handle']}」の登録",
+            (
+                f"「{selected['atcoder_handle']}」の共有登録"
+                if self.mode == "self" and selected["discord_id"] is None
+                else f"「{selected['atcoder_handle']}」の登録"
+            ),
             [(selected["id"], selected["channel_id"])],
+            self.mode == "self" and selected["discord_id"] is None,
         )
         self.rebuild_items()
         await interaction.response.edit_message(
@@ -627,9 +648,16 @@ class UnregisterView(discord.ui.View):
         )
 
     async def confirm_all(self, interaction):
+        records = self.records
+        if self.mode == "self":
+            records = [
+                record
+                for record in records
+                if record["discord_id"] == self.user_id
+            ]
         subscriptions = [
             (record["id"], record["channel_id"])
-            for record in self.records
+            for record in records
         ]
         if self.mode == "admin":
             if not await self.ensure_manager(interaction):
@@ -642,6 +670,7 @@ class UnregisterView(discord.ui.View):
         self.confirmation = (
             "自分の登録すべて",
             subscriptions,
+            False,
         )
         self.rebuild_items()
         await interaction.response.edit_message(
@@ -658,11 +687,12 @@ class UnregisterView(discord.ui.View):
         )
 
     async def confirm_delete(self, interaction):
-        _, subscriptions = self.confirmation
+        _, subscriptions, unlinked = self.confirmation
         await self.delete_confirmed(
             interaction,
             subscriptions,
             administrator=self.mode == "admin",
+            unlinked=unlinked,
         )
 
     async def delete_confirmed(
@@ -670,13 +700,36 @@ class UnregisterView(discord.ui.View):
         interaction,
         subscriptions,
         administrator,
+        unlinked=False,
     ):
         if administrator and not await self.ensure_manager(interaction):
             return
+        if unlinked and not all(
+            self.can_view_channel(channel_id, interaction.user)
+            for _, channel_id in subscriptions
+        ):
+            self.reload()
+            embed = self.build_embed()
+            embed.description = "通知先チャンネルの閲覧権限が必要です。"
+            await interaction.response.edit_message(embed=embed, view=self)
+            return
+        records = {
+            (record["id"], record["channel_id"]): record
+            for record in self.records
+        }
         deleted = delete_subscriptions(
             subscriptions,
             discord_id=None if administrator else self.user_id,
+            unlinked_only=unlinked,
         )
+        if unlinked and deleted:
+            record = records[subscriptions[0]]
+            print(
+                "共有登録を解除しました: "
+                f"actor_id={interaction.user.id} "
+                f"atcoder_handle={record['atcoder_handle']} "
+                f"channel_id={record['channel_id']}"
+            )
         self.reload()
         embed = self.build_embed()
         embed.description = f"{deleted}件の登録を解除しました。"

--- a/main.py
+++ b/main.py
@@ -15,7 +15,9 @@ import pytz
 
 from database import (
     DB_PATH,
+    delete_subscriptions,
     delete_subscriptions_for_channel,
+    get_subscriptions_for_channels,
     get_submission_poll_time,
     init_db,
     set_submission_poll_time,
@@ -31,12 +33,18 @@ ATCODER_SUBMISSIONS_URL = (
 )
 ATCODER_SUBMISSION_PAGE_LIMIT = 1000
 ATCODER_API_DELAY_SECONDS = 1.1
+UNREGISTER_PAGE_SIZE = 10
+UNREGISTER_STATUS = "アプデ: /unregisterで登録解除"
 
 
 intents = discord.Intents.default()
 intents.message_content = True
 
-bot = commands.Bot(command_prefix="!", intents=intents)
+bot = commands.Bot(
+    command_prefix="!",
+    intents=intents,
+    activity=discord.CustomActivity(name=UNREGISTER_STATUS),
+)
 
 config = configparser.ConfigParser()
 config.read("config.ini")
@@ -297,6 +305,395 @@ async def register(
     await interaction.response.send_message(
         f"{user_text} AtCoderのハンドル 「{atcoder_handle}」 を登録しました！\n"
         f"ACをした際の通知は {channel.mention} に送信されます。"
+    )
+
+
+class UnregisterConfirmationModal(discord.ui.Modal):
+    confirmation = discord.ui.TextInput(
+        label="確認のため「全件解除」と入力してください",
+        max_length=4,
+    )
+
+    def __init__(self, view, subscriptions):
+        super().__init__(title="サーバーの全登録を解除")
+        self.unregister_view = view
+        self.subscriptions = subscriptions
+
+    async def on_submit(self, interaction):
+        if self.confirmation.value != "全件解除":
+            await interaction.response.send_message(
+                "入力が一致しないため解除しませんでした。",
+                ephemeral=True,
+            )
+            return
+        await self.unregister_view.delete_confirmed(
+            interaction,
+            self.subscriptions,
+            administrator=True,
+        )
+
+
+class UnregisterView(discord.ui.View):
+    def __init__(self, interaction):
+        super().__init__(timeout=180)
+        self.user_id = interaction.user.id
+        self.member = interaction.user
+        self.guild = interaction.guild
+        self.mode = "self"
+        self.page = 0
+        self.selected_id = None
+        self.confirmation = None
+        self.records = []
+        self.reload()
+
+    @property
+    def is_manager(self):
+        return self.member.guild_permissions.manage_guild
+
+    def reload(self):
+        records = get_subscriptions_for_channels(
+            channel.id for channel in self.guild.channels
+        )
+        if self.mode == "self":
+            records = [
+                record
+                for record in records
+                if record["discord_id"] == self.user_id
+            ]
+        self.records = records
+        self.page = min(self.page, max(0, self.page_count - 1))
+        self.selected_id = None
+        self.confirmation = None
+        self.rebuild_items()
+
+    @property
+    def page_count(self):
+        return max(1, math.ceil(len(self.records) / UNREGISTER_PAGE_SIZE))
+
+    @property
+    def page_records(self):
+        start = self.page * UNREGISTER_PAGE_SIZE
+        return self.records[start : start + UNREGISTER_PAGE_SIZE]
+
+    def channel_text(self, channel_id, plain=False):
+        channel = self.guild.get_channel(channel_id)
+        if (
+            channel is not None
+            and channel.permissions_for(self.member).view_channel
+        ):
+            return f"#{channel.name}" if plain else channel.mention
+        return "閲覧権限のないチャンネル"
+
+    def owner_text(self, discord_id, plain=False):
+        if discord_id is None:
+            return "ユーザー未紐づけ"
+        member = self.guild.get_member(discord_id)
+        if member is None:
+            return f"Discord ID: {discord_id}"
+        return member.display_name if plain else member.mention
+
+    def build_embed(self):
+        if self.confirmation is not None:
+            label, subscriptions = self.confirmation
+            return discord.Embed(
+                title="登録解除の確認",
+                description=(
+                    f"{label}（{len(subscriptions)}件）を解除します。\n"
+                    "この操作は取り消せません。"
+                ),
+                color=discord.Color.red(),
+            )
+
+        title = (
+            "サーバー内の登録管理"
+            if self.mode == "admin"
+            else "登録解除"
+        )
+        if not self.records:
+            description = "対象の登録はありません。"
+        else:
+            description = "解除する登録を選択してください。"
+
+        embed = discord.Embed(
+            title=title,
+            description=description,
+            color=discord.Color.blue(),
+        )
+        for record in self.page_records:
+            value = f"通知先: {self.channel_text(record['channel_id'])}"
+            if self.mode == "admin":
+                value += f"\nユーザー: {self.owner_text(record['discord_id'])}"
+            embed.add_field(
+                name=record["atcoder_handle"],
+                value=value,
+                inline=False,
+            )
+        if self.records:
+            embed.set_footer(
+                text=(
+                    f"{len(self.records)}件 "
+                    f"（{self.page + 1}/{self.page_count}ページ）"
+                )
+            )
+        return embed
+
+    def rebuild_items(self):
+        self.clear_items()
+
+        if self.confirmation is not None:
+            cancel = discord.ui.Button(
+                label="戻る",
+                style=discord.ButtonStyle.secondary,
+            )
+            cancel.callback = self.cancel_confirmation
+            self.add_item(cancel)
+
+            confirm = discord.ui.Button(
+                label="解除を確定",
+                style=discord.ButtonStyle.danger,
+            )
+            confirm.callback = self.confirm_delete
+            self.add_item(confirm)
+            return
+
+        if self.records:
+            options = []
+            for record in self.page_records:
+                channel = self.channel_text(record["channel_id"], plain=True)
+                description = f"通知先: {channel}"
+                if self.mode == "admin":
+                    owner = self.owner_text(record["discord_id"], plain=True)
+                    description += f" / {owner}"
+                options.append(
+                    discord.SelectOption(
+                        label=record["atcoder_handle"][:100],
+                        value=str(record["id"]),
+                        description=description[:100],
+                    )
+                )
+            select = discord.ui.Select(
+                placeholder="解除する登録を選択",
+                options=options,
+                row=0,
+            )
+            select.callback = self.select_subscription
+            self.add_item(select)
+
+            previous = discord.ui.Button(
+                label="前へ",
+                style=discord.ButtonStyle.secondary,
+                disabled=self.page == 0,
+                row=1,
+            )
+            previous.callback = self.previous_page
+            self.add_item(previous)
+
+            following = discord.ui.Button(
+                label="次へ",
+                style=discord.ButtonStyle.secondary,
+                disabled=self.page + 1 >= self.page_count,
+                row=1,
+            )
+            following.callback = self.next_page
+            self.add_item(following)
+
+            remove = discord.ui.Button(
+                label="選択した登録を解除",
+                style=discord.ButtonStyle.danger,
+                disabled=self.selected_id is None,
+                row=1,
+            )
+            remove.callback = self.confirm_selected
+            self.add_item(remove)
+
+            remove_all = discord.ui.Button(
+                label=(
+                    "このサーバーの全登録を解除"
+                    if self.mode == "admin"
+                    else "自分の登録をすべて解除"
+                ),
+                style=discord.ButtonStyle.danger,
+                row=2,
+            )
+            remove_all.callback = self.confirm_all
+            self.add_item(remove_all)
+
+        if self.mode == "admin":
+            back = discord.ui.Button(
+                label="自分の登録に戻る",
+                style=discord.ButtonStyle.secondary,
+                row=3,
+            )
+            back.callback = self.show_self
+            self.add_item(back)
+        elif self.is_manager:
+            admin = discord.ui.Button(
+                label="サーバー内の登録を管理",
+                style=discord.ButtonStyle.primary,
+                row=3,
+            )
+            admin.callback = self.show_admin
+            self.add_item(admin)
+
+    async def interaction_check(self, interaction):
+        if interaction.user.id == self.user_id:
+            return True
+        await interaction.response.send_message(
+            "このメニューは操作できません。",
+            ephemeral=True,
+        )
+        return False
+
+    async def ensure_manager(self, interaction):
+        if interaction.user.guild_permissions.manage_guild:
+            return True
+        await interaction.response.send_message(
+            "サーバーの管理権限が必要です。",
+            ephemeral=True,
+        )
+        return False
+
+    async def select_subscription(self, interaction):
+        self.selected_id = int(interaction.data["values"][0])
+        self.rebuild_items()
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+    async def previous_page(self, interaction):
+        self.page -= 1
+        self.selected_id = None
+        self.rebuild_items()
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+    async def next_page(self, interaction):
+        self.page += 1
+        self.selected_id = None
+        self.rebuild_items()
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+    async def show_admin(self, interaction):
+        if not await self.ensure_manager(interaction):
+            return
+        self.mode = "admin"
+        self.page = 0
+        self.reload()
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+    async def show_self(self, interaction):
+        self.mode = "self"
+        self.page = 0
+        self.reload()
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+    async def confirm_selected(self, interaction):
+        selected = next(
+            (
+                record
+                for record in self.records
+                if record["id"] == self.selected_id
+            ),
+            None,
+        )
+        if selected is None:
+            await interaction.response.send_message(
+                "登録が見つかりません。メニューを開き直してください。",
+                ephemeral=True,
+            )
+            return
+        if self.mode == "admin" and not await self.ensure_manager(interaction):
+            return
+        self.confirmation = (
+            f"「{selected['atcoder_handle']}」の登録",
+            [(selected["id"], selected["channel_id"])],
+        )
+        self.rebuild_items()
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+    async def confirm_all(self, interaction):
+        subscriptions = [
+            (record["id"], record["channel_id"])
+            for record in self.records
+        ]
+        if self.mode == "admin":
+            if not await self.ensure_manager(interaction):
+                return
+            await interaction.response.send_modal(
+                UnregisterConfirmationModal(self, subscriptions)
+            )
+            return
+
+        self.confirmation = (
+            "自分の登録すべて",
+            subscriptions,
+        )
+        self.rebuild_items()
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+    async def cancel_confirmation(self, interaction):
+        self.confirmation = None
+        self.rebuild_items()
+        await interaction.response.edit_message(
+            embed=self.build_embed(),
+            view=self,
+        )
+
+    async def confirm_delete(self, interaction):
+        _, subscriptions = self.confirmation
+        await self.delete_confirmed(
+            interaction,
+            subscriptions,
+            administrator=self.mode == "admin",
+        )
+
+    async def delete_confirmed(
+        self,
+        interaction,
+        subscriptions,
+        administrator,
+    ):
+        if administrator and not await self.ensure_manager(interaction):
+            return
+        deleted = delete_subscriptions(
+            subscriptions,
+            discord_id=None if administrator else self.user_id,
+        )
+        self.reload()
+        embed = self.build_embed()
+        embed.description = f"{deleted}件の登録を解除しました。"
+        await interaction.response.edit_message(embed=embed, view=self)
+
+
+@bot.tree.command(
+    name="unregister",
+    description="AC通知の登録を解除します",
+)
+@app_commands.guild_only()
+async def unregister(interaction: discord.Interaction):
+    view = UnregisterView(interaction)
+    await interaction.response.send_message(
+        embed=view.build_embed(),
+        view=view,
+        ephemeral=True,
     )
 
 

--- a/test_database.py
+++ b/test_database.py
@@ -4,7 +4,9 @@ import unittest
 from pathlib import Path
 
 from database import (
+    delete_subscriptions,
     delete_subscriptions_for_channel,
+    get_subscriptions_for_channels,
     get_submission_poll_time,
     init_db,
     set_submission_poll_time,
@@ -112,6 +114,49 @@ class InitDbTest(unittest.TestCase):
 
             set_submission_poll_time(20001, db_path)
             self.assertEqual(get_submission_poll_time(db_path), 20001)
+
+    def test_lists_by_channel_and_deletes_only_the_owner(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "bot.db"
+            init_db(db_path)
+            with sqlite3.connect(db_path) as conn:
+                conn.executemany(
+                    """
+                    INSERT INTO subscriptions (
+                        discord_id,
+                        atcoder_handle,
+                        channel_id
+                    )
+                    VALUES (?, ?, ?)
+                    """,
+                    [
+                        (1, "alice", 101),
+                        (2, "bob", 101),
+                        (1, "carol", 102),
+                        (None, "dave", 103),
+                    ],
+                )
+
+            rows = get_subscriptions_for_channels([101, 102], db_path)
+            self.assertEqual(
+                [
+                    (row["discord_id"], row["atcoder_handle"], row["channel_id"])
+                    for row in rows
+                ],
+                [(1, "alice", 101), (2, "bob", 101), (1, "carol", 102)],
+            )
+
+            targets = [(row["id"], row["channel_id"]) for row in rows]
+            self.assertEqual(delete_subscriptions(targets, 1, db_path), 2)
+
+            remaining = get_subscriptions_for_channels([101, 102, 103], db_path)
+            self.assertEqual(
+                [
+                    (row["discord_id"], row["atcoder_handle"])
+                    for row in remaining
+                ],
+                [(2, "bob"), (None, "dave")],
+            )
 
 
 if __name__ == "__main__":

--- a/test_database.py
+++ b/test_database.py
@@ -158,6 +158,27 @@ class InitDbTest(unittest.TestCase):
                 [(2, "bob"), (None, "dave")],
             )
 
+            targets = [
+                (row["id"], row["channel_id"])
+                for row in remaining
+            ]
+            self.assertEqual(
+                delete_subscriptions(
+                    targets,
+                    db_path=db_path,
+                    unlinked_only=True,
+                ),
+                1,
+            )
+            remaining = get_subscriptions_for_channels([101, 102, 103], db_path)
+            self.assertEqual(
+                [
+                    (row["discord_id"], row["atcoder_handle"])
+                    for row in remaining
+                ],
+                [(2, "bob")],
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_unregister.py
+++ b/test_unregister.py
@@ -78,9 +78,21 @@ class UnregisterViewTest(unittest.IsolatedAsyncioTestCase):
                 "atcoder_handle": "bob",
                 "channel_id": 101,
             },
+            {
+                "id": 4,
+                "discord_id": None,
+                "atcoder_handle": "dave",
+                "channel_id": 101,
+            },
+            {
+                "id": 5,
+                "discord_id": None,
+                "atcoder_handle": "eve",
+                "channel_id": 102,
+            },
         ]
 
-    async def test_filters_self_masks_private_channel_and_allows_admin_view(self):
+    async def test_shows_self_and_visible_shared_records(self):
         with patch.object(
             main,
             "get_subscriptions_for_channels",
@@ -88,12 +100,16 @@ class UnregisterViewTest(unittest.IsolatedAsyncioTestCase):
         ):
             view = main.UnregisterView(self.interaction)
 
-            self.assertEqual([row["id"] for row in view.records], [1, 2])
+            self.assertEqual([row["id"] for row in view.records], [1, 2, 4])
             embed = view.build_embed()
             self.assertEqual(embed.fields[0].value, "通知先: <#101>")
             self.assertEqual(
                 embed.fields[1].value,
                 "通知先: 閲覧権限のないチャンネル",
+            )
+            self.assertEqual(
+                embed.fields[2].value,
+                "通知先: <#101>\n共有登録（Discordユーザー未紐づけ）",
             )
             self.assertIn(
                 "サーバー内の登録を管理",
@@ -106,7 +122,10 @@ class UnregisterViewTest(unittest.IsolatedAsyncioTestCase):
 
             view.mode = "admin"
             view.reload()
-            self.assertEqual([row["id"] for row in view.records], [1, 2, 3])
+            self.assertEqual(
+                [row["id"] for row in view.records],
+                [1, 2, 3, 4, 5],
+            )
 
     async def test_delete_keeps_owner_check(self):
         response = SimpleNamespace(edit_message=AsyncMock())
@@ -130,7 +149,89 @@ class UnregisterViewTest(unittest.IsolatedAsyncioTestCase):
                 administrator=False,
             )
 
-        delete.assert_called_once_with([(1, 101)], discord_id=1)
+        delete.assert_called_once_with(
+            [(1, 101)],
+            discord_id=1,
+            unlinked_only=False,
+        )
+        response.edit_message.assert_awaited_once()
+
+    async def test_shared_delete_requires_record_to_remain_unlinked(self):
+        response = SimpleNamespace(edit_message=AsyncMock())
+        interaction = SimpleNamespace(
+            user=self.user,
+            guild=self.guild,
+            response=response,
+        )
+        with (
+            patch.object(
+                main,
+                "get_subscriptions_for_channels",
+                return_value=self.records,
+            ),
+            patch.object(main, "delete_subscriptions", return_value=1) as delete,
+            patch("builtins.print") as log,
+        ):
+            view = main.UnregisterView(self.interaction)
+            await view.delete_confirmed(
+                interaction,
+                [(4, 101)],
+                administrator=False,
+                unlinked=True,
+            )
+
+        delete.assert_called_once_with(
+            [(4, 101)],
+            discord_id=1,
+            unlinked_only=True,
+        )
+        log.assert_called_once()
+
+    async def test_self_bulk_delete_excludes_shared_records(self):
+        response = SimpleNamespace(edit_message=AsyncMock())
+        interaction = SimpleNamespace(
+            user=self.user,
+            guild=self.guild,
+            response=response,
+        )
+        with patch.object(
+            main,
+            "get_subscriptions_for_channels",
+            return_value=self.records,
+        ):
+            view = main.UnregisterView(self.interaction)
+            await view.confirm_all(interaction)
+
+        self.assertEqual(
+            view.confirmation,
+            ("自分の登録すべて", [(1, 101), (2, 102)], False),
+        )
+
+    async def test_shared_delete_rechecks_channel_visibility(self):
+        response = SimpleNamespace(edit_message=AsyncMock())
+        interaction = SimpleNamespace(
+            user=self.user,
+            guild=self.guild,
+            response=response,
+        )
+        with (
+            patch.object(
+                main,
+                "get_subscriptions_for_channels",
+                return_value=self.records,
+            ),
+            patch.object(main, "delete_subscriptions") as delete,
+        ):
+            view = main.UnregisterView(self.interaction)
+            self.guild.get_channel(101).visible = False
+            await view.delete_confirmed(
+                interaction,
+                [(4, 101)],
+                administrator=False,
+                unlinked=True,
+            )
+
+        delete.assert_not_called()
         response.edit_message.assert_awaited_once()
 
     async def test_admin_delete_rechecks_permission(self):

--- a/test_unregister.py
+++ b/test_unregister.py
@@ -1,0 +1,170 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import main
+
+
+class Channel:
+    def __init__(self, channel_id, name, visible=True):
+        self.id = channel_id
+        self.name = name
+        self.mention = f"<#{channel_id}>"
+        self.visible = visible
+
+    def permissions_for(self, member):
+        return SimpleNamespace(view_channel=self.visible)
+
+
+class Guild:
+    def __init__(self, members, channels):
+        self.members = {member.id: member for member in members}
+        self.channels = channels
+
+    def get_member(self, member_id):
+        return self.members.get(member_id)
+
+    def get_channel(self, channel_id):
+        return next(
+            (
+                channel
+                for channel in self.channels
+                if channel.id == channel_id
+            ),
+            None,
+        )
+
+
+def member(member_id, manage_guild=False):
+    return SimpleNamespace(
+        id=member_id,
+        mention=f"<@{member_id}>",
+        display_name=f"user-{member_id}",
+        guild_permissions=SimpleNamespace(manage_guild=manage_guild),
+    )
+
+
+class UnregisterViewTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.user = member(1, manage_guild=True)
+        self.other = member(2)
+        self.guild = Guild(
+            [self.user, self.other],
+            [
+                Channel(101, "visible"),
+                Channel(102, "private", visible=False),
+            ],
+        )
+        self.interaction = SimpleNamespace(
+            user=self.user,
+            guild=self.guild,
+        )
+        self.records = [
+            {
+                "id": 1,
+                "discord_id": 1,
+                "atcoder_handle": "alice",
+                "channel_id": 101,
+            },
+            {
+                "id": 2,
+                "discord_id": 1,
+                "atcoder_handle": "carol",
+                "channel_id": 102,
+            },
+            {
+                "id": 3,
+                "discord_id": 2,
+                "atcoder_handle": "bob",
+                "channel_id": 101,
+            },
+        ]
+
+    async def test_filters_self_masks_private_channel_and_allows_admin_view(self):
+        with patch.object(
+            main,
+            "get_subscriptions_for_channels",
+            return_value=self.records,
+        ):
+            view = main.UnregisterView(self.interaction)
+
+            self.assertEqual([row["id"] for row in view.records], [1, 2])
+            embed = view.build_embed()
+            self.assertEqual(embed.fields[0].value, "通知先: <#101>")
+            self.assertEqual(
+                embed.fields[1].value,
+                "通知先: 閲覧権限のないチャンネル",
+            )
+            self.assertIn(
+                "サーバー内の登録を管理",
+                [
+                    item.label
+                    for item in view.children
+                    if hasattr(item, "label")
+                ],
+            )
+
+            view.mode = "admin"
+            view.reload()
+            self.assertEqual([row["id"] for row in view.records], [1, 2, 3])
+
+    async def test_delete_keeps_owner_check(self):
+        response = SimpleNamespace(edit_message=AsyncMock())
+        interaction = SimpleNamespace(
+            user=self.user,
+            guild=self.guild,
+            response=response,
+        )
+        with (
+            patch.object(
+                main,
+                "get_subscriptions_for_channels",
+                return_value=self.records,
+            ),
+            patch.object(main, "delete_subscriptions", return_value=1) as delete,
+        ):
+            view = main.UnregisterView(self.interaction)
+            await view.delete_confirmed(
+                interaction,
+                [(1, 101)],
+                administrator=False,
+            )
+
+        delete.assert_called_once_with([(1, 101)], discord_id=1)
+        response.edit_message.assert_awaited_once()
+
+    async def test_admin_delete_rechecks_permission(self):
+        response = SimpleNamespace(
+            edit_message=AsyncMock(),
+            send_message=AsyncMock(),
+        )
+        self.user.guild_permissions.manage_guild = False
+        interaction = SimpleNamespace(
+            user=self.user,
+            guild=self.guild,
+            response=response,
+        )
+        with (
+            patch.object(
+                main,
+                "get_subscriptions_for_channels",
+                return_value=self.records,
+            ),
+            patch.object(main, "delete_subscriptions") as delete,
+        ):
+            view = main.UnregisterView(self.interaction)
+            await view.delete_confirmed(
+                interaction,
+                [(3, 101)],
+                administrator=True,
+            )
+
+        delete.assert_not_called()
+        response.send_message.assert_awaited_once_with(
+            "サーバーの管理権限が必要です。",
+            ephemeral=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
- `/unregister` のEphemeral登録解除メニューを追加
- 本人の個別・一括解除と、`Manage Guild` 権限者向けのサーバー内管理を追加
- 閲覧可能なチャンネルの共有登録（Discordユーザー未紐づけ）を通常ユーザーも個別解除可能
- 非公開チャンネル名のマスク、ページ切り替え、削除確認を追加
- サーバー全解除では `全件解除` の入力確認を必須化
- 起動時ステータスに `/unregister` の案内を表示

## 安全対策
- 共有登録は自分の一括解除に含めない
- 共有登録の削除時にチャンネル閲覧権限と `discord_id IS NULL` を再検証
- 共有登録を解除した実行者・AtCoderハンドル・チャンネルをログ出力

## テスト
- `python3 -m unittest -v`（18件成功）
- `py_compile`、`git diff --check` 成功
- 本番DBを読み取り専用で整合性確認
- 本番DBのオンラインスナップショット（88件、共有8件）で共有限定削除を確認
- ライブの本番DBは未変更