### PR TITLE
fix: /unregisterでサーバーニックネームを表示

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ UNREGISTER_STATUS = "アプデ: /unregisterで登録解除"
 
 
 intents = discord.Intents.default()
+intents.members = True
 intents.message_content = True
 
 bot = commands.Bot(
@@ -397,7 +398,7 @@ class UnregisterView(discord.ui.View):
             return "ユーザー未紐づけ"
         member = self.guild.get_member(discord_id)
         if member is None:
-            return f"Discord ID: {discord_id}"
+            return f"Discord ID: {discord_id}" if plain else f"<@{discord_id}>"
         return member.display_name if plain else member.mention
 
     def build_embed(self):

--- a/test_unregister.py
+++ b/test_unregister.py
@@ -111,6 +111,11 @@ class UnregisterViewTest(unittest.IsolatedAsyncioTestCase):
                 embed.fields[2].value,
                 "通知先: <#101>\n共有登録（Discordユーザー未紐づけ）",
             )
+            self.assertEqual(view.owner_text(999), "<@999>")
+            self.assertEqual(
+                view.owner_text(999, plain=True),
+                "Discord ID: 999",
+            )
             self.assertIn(
                 "サーバー内の登録を管理",
                 [
@@ -126,6 +131,13 @@ class UnregisterViewTest(unittest.IsolatedAsyncioTestCase):
                 [row["id"] for row in view.records],
                 [1, 2, 3, 4, 5],
             )
+            select = next(
+                item
+                for item in view.children
+                if hasattr(item, "options")
+            )
+            bob = next(option for option in select.options if option.value == "3")
+            self.assertIn("user-2", bob.description)
 
     async def test_delete_keeps_owner_check(self):
         response = SimpleNamespace(edit_message=AsyncMock())


### PR DESCRIPTION
## 変更内容
- `Server Members Intent` を有効化してサーバーメンバーをキャッシュ
- `/unregister` のドロップダウンにサーバープロフィールの表示名（ニックネーム）を表示
- Embedではキャッシュ外ユーザーもDiscordメンション形式で表示

## 原因
`Intents.default()` ではMembers Intentが無効なため、多くのユーザーがメンバーキャッシュに存在せず、Discord ID表示へフォールバックしていました。

## 影響
Discord Developer Portal側で「Server Members Intent」が有効である必要があります。既存の登録データやDBスキーマは変更しません。

## テスト
- `python3 -m unittest -v`（18件成功）
- `py_compile`、`git diff --check` 成功
